### PR TITLE
Compatibility with copy-webpack-plugin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,7 +60,9 @@ export default (options = {}) => {
                 let bundleBody,
                     outputFilePath;
 
-                if (options.test && !options.test.test(assetPath)) {
+                // Don't include webpack's hot update files
+                if ((options.test && !options.test.test(assetPath)) || 
+                    assetPath.indexOf('hot-update') > -1) {
                     return;
                 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -53,29 +53,22 @@ export default (options = {}) => {
 
             mkdirp.sync(outputPath);
 
-            files = _.map(stats.compilation.assets, 'existsAt');
+            files = _.map(stats.compilation.chunks, 'files');
             files = _.flatten(files);
 
-            _.forEach(files, (assetPath) => {
+            _.forEach(files, (bundleFileName) => {
                 let bundleBody,
+                    bundleFilePath,
                     outputFilePath;
 
-                if (options.test && !options.test.test(assetPath)) {
+                if (options.test && !options.test.test(bundleFileName)) {
                     return;
                 }
 
-                bundleBody = compiler.outputFileSystem.readFileSync(assetPath);
-                outputFilePath = path.join(outputPath, assetPath);
+                bundleFilePath = path.posix.join(compiler.options.output.path, bundleFileName);
+                bundleBody = compiler.outputFileSystem.readFileSync(bundleFilePath);
+                outputFilePath = path.join(outputPath, bundleFileName);
 
-	            // When using copy-webpack-plugin the assetPath may contain folders
-	            try {
-		            fs.statSync(path.dirname(outputFilePath))
-	            } catch (err) {
-		            if (err && err.code === 'ENOENT') {
-			            mkdirp(path.dirname(outputFilePath))
-		            }
-	            }
-	            
                 fs.writeFileSync(outputFilePath, bundleBody);
             });
         });

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ export default (options = {}) => {
                     return;
                 }
 
-                bundleFilePath = path.join(compiler.options.output.path, bundleFileName);
+                bundleFilePath = path.posix.join(compiler.options.output.path, bundleFileName);
                 bundleBody = compiler.outputFileSystem.readFileSync(bundleFilePath);
                 outputFilePath = path.join(outputPath, bundleFileName);
 

--- a/src/index.js
+++ b/src/index.js
@@ -53,22 +53,29 @@ export default (options = {}) => {
 
             mkdirp.sync(outputPath);
 
-            files = _.map(stats.compilation.chunks, 'files');
+            files = _.map(stats.compilation.assets, 'existsAt');
             files = _.flatten(files);
 
-            _.forEach(files, (bundleFileName) => {
+            _.forEach(files, (assetPath) => {
                 let bundleBody,
-                    bundleFilePath,
                     outputFilePath;
 
-                if (options.test && !options.test.test(bundleFileName)) {
+                if (options.test && !options.test.test(assetPath)) {
                     return;
                 }
 
-                bundleFilePath = path.posix.join(compiler.options.output.path, bundleFileName);
-                bundleBody = compiler.outputFileSystem.readFileSync(bundleFilePath);
-                outputFilePath = path.join(outputPath, bundleFileName);
+                bundleBody = compiler.outputFileSystem.readFileSync(assetPath);
+                outputFilePath = path.join(outputPath, assetPath);
 
+	            // When using copy-webpack-plugin the assetPath may contain folders
+	            try {
+		            fs.statSync(path.dirname(outputFilePath))
+	            } catch (err) {
+		            if (err && err.code === 'ENOENT') {
+			            mkdirp(path.dirname(outputFilePath))
+		            }
+	            }
+	            
                 fs.writeFileSync(outputFilePath, bundleBody);
             });
         });


### PR DESCRIPTION
This PR makes the plugin compatible with `copy-webpack-plugin`. I haven't tested it very thoroughly yet (which I'll do probably tomorrow), but it seems to work correctly.

In order to make it work I had to read from `compilation.assets` instead of `compilation.chunks` since that's what `copy-webpack-plugin` uses. I'm not very knowledgeable about webpack's internals so I'm not sure if there is some breaking difference between those two though so far I haven't found any.
