### PR TITLE
Returns early when 'webpack' is used

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,6 +100,10 @@ export default (userOptions = {}) => {
 
         compiler.plugin('done', (stats) => {
             setup();
+            
+	    if (!outputPath) {
+	    	return;
+	    }
 
             if (stats.compilation.errors.length) {
                 return;


### PR DESCRIPTION
The 'setup' function returns early when it detects webpack running outside a dev server here:

``` javascript
if (!isMemoryFileSystem(compiler.outputFileSystem)) {
  return;
}
```

which prevent the `outputPath` variable to be set a few lines after.

``` javascript
outputPath = compiler.options.devServer.outputPath;
```

This is the intended behavior I guess, but now nothing stops the plugin from trying to iterate through assets after the initial setup, which logically produces an error in `outputFilePath = path.join(outputPath, assetPath);` when outputPath is undefined, on windows at least.

**returning when `outputPath` is undefined prevents this from happening.**
