### PR TITLE
ignore compiler.options.output.path when it equal '/'

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,10 @@ export default (userOptions = {}) => {
             }
 
             // https://github.com/gajus/write-file-webpack-plugin/issues/1
-            if (_.has(compiler, 'options.output.path') && compiler.options.output.path !== path.sep) {
+            // `compiler.options.output.path` will be hardcoded to '/' in
+            // webpack-dev-server's command line wrapper. So it should be
+            // ignored here.
+            if (_.has(compiler, 'options.output.path') && compiler.options.output.path !== '/') {
                 outputPath = compiler.options.output.path;
             }
 


### PR DESCRIPTION
mentioned in #5 .

I removed `path.sep` and use `/`, because webpack-dev-server's command line wrapper will hard code `compiler.options.output.path` to `/` whenever the platform is. But `path.sep` is different on *nix and windows.
