### PR TITLE
Option force to use plugin with webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ npm install write-file-webpack-plugin --save-dev
  * @property {RegExp} test A regular expression used to test if file should be written. When not present, all bundle will be written.
  * @property {boolean} useHashIndex Use hash index to write only files that have changed since the last iteration (default: true).
  * @property {boolean} log Logs names of the files that are being written (or skipped because they have not changed) (default: true).
+ * @property {boolean} force Forces the execution of the plugin regardless of being using `webpack-dev-server` or not (default: false).
  */
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,8 @@ export default (userOptions: UserOptionsType = {}): Object => {
         exitOnErrors: true,
         log: true,
         test: null,
-        useHashIndex: true
+        useHashIndex: true,
+        force: false
     }, userOptions);
 
     if (!_.isNull(options.test) && !_.isRegExp(options.test)) {
@@ -52,6 +53,10 @@ export default (userOptions: UserOptionsType = {}): Object => {
 
     if (!_.isBoolean(options.exitOnErrors)) {
         throw new Error('options.exitOnErrors value must be of boolean type.');
+    }
+
+    if (!_.isBoolean(options.force)) {
+        throw new Error('options.force value must be of boolean type.');
     }
 
     const log = (...append) => {
@@ -82,7 +87,7 @@ export default (userOptions: UserOptionsType = {}): Object => {
 
             log('compiler.outputFileSystem is "' + chalk.cyan(compiler.outputFileSystem.constructor.name) + '".');
 
-            if (!isMemoryFileSystem(compiler.outputFileSystem)) {
+            if (!isMemoryFileSystem(compiler.outputFileSystem) && !options.force) {
                 return false;
             }
 


### PR DESCRIPTION
Use case :
- I can't use webpack-dev-server (mostly because I am doing SSR)
- My node server is using webpack node API with webpackDevMiddleware and webpackHotMiddleware
- I want hot reload and up to date code when I refresh my browser, without having to rebuild everything
- I don't want to run a separate webpack --watch aside my HMR server because of RAM consumption
- I don't mind the overhead of rewriting my files at first compile time

Moreover I think this plugin should rely on something more independent than `compiler.outputFileSystem` which may be subject to change.