### PR TITLE
Add babel-plugin-transform-es2015-spread

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,7 @@
     "add-module-exports",
     "transform-es2015-modules-commonjs",
     "transform-flow-strip-types",
-    "transform-es2015-parameters"
+    "transform-es2015-parameters",
+    "transform-es2015-spread"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.18.0",
     "babel-plugin-transform-es2015-parameters": "^6.18.0",
+    "babel-plugin-transform-es2015-spread": "^6.8.0",
     "babel-plugin-transform-flow-strip-types": "^6.18.0",
     "eslint": "^3.9.1",
     "eslint-config-canonical": "^4.0.0",


### PR DESCRIPTION
Webpack throws an error when requiring <b>write-file-webpack-plugin@3.4.1</b>. The generated file didn't transform `...append` into ES5 syntax:

dist/index.js
```js
console.log(_chalk2.default.dim('[' + (0, _moment2.default)().format('HH:mm:ss') + '] [write-file-webpack-plugin]'), 
...append);
```

With ES2015 spread plugin, it will produce correct result like this:
```js
(_console = console).log.apply(_console, [_chalk2.default.dim('[' + (0, _moment2.default)().format('HH:   mm:ss') + '] [write-file-webpack-plugin]')].concat(append));};
```