### PR TITLE
Webpack 2 support. Fixes #30

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Forces `webpack-dev-server` program to write bundle files to the file system.
 
-This plugin has no effect when [`webpack`](https://webpack.github.io/docs/usage.html) program 
+This plugin has no effect when [`webpack`](https://webpack.github.io/docs/usage.html) program
 is used instead of [`webpack-dev-server`](https://webpack.github.io/docs/webpack-dev-server.html).
 
 ## Install
@@ -19,10 +19,11 @@ npm install write-file-webpack-plugin --save-dev
 ```js
 /**
  * @typedef {Object} options
+ * @property {boolean} exitOnErrors Stop writing files on webpack errors (default: true).
+ * @property {boolean} force Forces the execution of the plugin regardless of being using `webpack-dev-server` or not (default: false).
+ * @property {boolean} log Logs names of the files that are being written (or skipped because they have not changed) (default: true).
  * @property {RegExp} test A regular expression used to test if file should be written. When not present, all bundle will be written.
  * @property {boolean} useHashIndex Use hash index to write only files that have changed since the last iteration (default: true).
- * @property {boolean} log Logs names of the files that are being written (or skipped because they have not changed) (default: true).
- * @property {boolean} force Forces the execution of the plugin regardless of being using `webpack-dev-server` or not (default: false).
  */
 
 /**
@@ -42,16 +43,11 @@ new WriteFilePlugin({
 
 Configure [`webpack.config.js`](https://webpack.github.io/docs/configuration.html) to use the `write-file-webpack-plugin` plugin.
 
-You must add `outputPath` property to the `devServer` configuration (For explanation see https://github.com/gajus/write-file-webpack-plugin/issues/1). `devServer.outputPath` value must be equal to `output.path` configuration value.
-
 ```js
 import path from 'path';
 import WriteFilePlugin from 'write-file-webpack-plugin';
 
 export default {
-    devServer: {
-        outputPath: path.join(__dirname, './dist')
-    },
     output: {
         path: path.join(__dirname, './dist')
     },

--- a/src/index.js
+++ b/src/index.js
@@ -18,16 +18,19 @@ const isMemoryFileSystem = (outputFileSystem: Object): boolean => {
 };
 
 /**
- * @property test A regular expression used to test if file should be written. When not present, all bundle will be written.
- * @property useHashIndex Use hash index to write only files that have changed since the last iteration (default: true).
- * @property log Logs names of the files that are being written (or skipped because they have not changed) (default: true).
- * @property exitOnErors Stop writing files on webpack errors (default: true).
+ * @typedef {Object} options
+ * @property {boolean} exitOnErrors Stop writing files on webpack errors (default: true).
+ * @property {RegExp} test A regular expression used to test if file should be written. When not present, all bundle will be written.
+ * @property {boolean} useHashIndex Use hash index to write only files that have changed since the last iteration (default: true).
+ * @property {boolean} log Logs names of the files that are being written (or skipped because they have not changed) (default: true).
+ * @property {boolean} force Forces the execution of the plugin regardless of being using `webpack-dev-server` or not (default: false).
  */
 type UserOptionsType = {
   exitOnErrors: ?boolean,
   test: ?RegExp,
   useHashIndex: ?boolean,
-  log: ?boolean
+  log: ?boolean,
+  force: ?boolean
 };
 
 export default (userOptions: UserOptionsType = {}): Object => {
@@ -39,6 +42,10 @@ export default (userOptions: UserOptionsType = {}): Object => {
     useHashIndex: true
   }, userOptions);
 
+  if (!_.isBoolean(options.exitOnErrors)) {
+    throw new Error('options.exitOnErrors value must be of boolean type.');
+  }
+
   if (!_.isNull(options.test) && !_.isRegExp(options.test)) {
     throw new Error('options.test value must be an instance of RegExp.');
   }
@@ -49,10 +56,6 @@ export default (userOptions: UserOptionsType = {}): Object => {
 
   if (!_.isBoolean(options.log)) {
     throw new Error('options.log value must be of boolean type.');
-  }
-
-  if (!_.isBoolean(options.exitOnErrors)) {
-    throw new Error('options.exitOnErrors value must be of boolean type.');
   }
 
   if (!_.isBoolean(options.force)) {
@@ -90,23 +93,15 @@ export default (userOptions: UserOptionsType = {}): Object => {
         return false;
       }
 
-      // https://github.com/gajus/write-file-webpack-plugin/issues/1
-      // `compiler.options.output.path` will be hardcoded to '/' in
-      // webpack-dev-server's command line wrapper. So it should be
-      // ignored here.
       if (_.has(compiler, 'options.output.path') && compiler.options.output.path !== '/') {
         outputPath = compiler.options.output.path;
       }
 
       if (!outputPath) {
-        if (!_.has(compiler, 'options.devServer.outputPath')) {
-          throw new Error('output.path is not accessible and devServer.outputPath is not defined. Define devServer.outputPath.');
-        }
-
-        outputPath = compiler.options.devServer.outputPath;
+        throw new Error('output.path is not. Define output.path.');
       }
 
-      log('compiler.options.devServer.outputPath is "' + chalk.cyan(outputPath) + '".');
+      log('outputPath is "' + chalk.cyan(outputPath) + '".');
 
       setupStatus = true;
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,10 +20,10 @@ const isMemoryFileSystem = (outputFileSystem: Object): boolean => {
 /**
  * @typedef {Object} options
  * @property {boolean} exitOnErrors Stop writing files on webpack errors (default: true).
+ * @property {boolean} force Forces the execution of the plugin regardless of being using `webpack-dev-server` or not (default: false).
+ * @property {boolean} log Logs names of the files that are being written (or skipped because they have not changed) (default: true).
  * @property {RegExp} test A regular expression used to test if file should be written. When not present, all bundle will be written.
  * @property {boolean} useHashIndex Use hash index to write only files that have changed since the last iteration (default: true).
- * @property {boolean} log Logs names of the files that are being written (or skipped because they have not changed) (default: true).
- * @property {boolean} force Forces the execution of the plugin regardless of being using `webpack-dev-server` or not (default: false).
  */
 type UserOptionsType = {
   exitOnErrors: ?boolean,
@@ -46,20 +46,20 @@ export default (userOptions: UserOptionsType = {}): Object => {
     throw new Error('options.exitOnErrors value must be of boolean type.');
   }
 
-  if (!_.isNull(options.test) && !_.isRegExp(options.test)) {
-    throw new Error('options.test value must be an instance of RegExp.');
-  }
-
-  if (!_.isBoolean(options.useHashIndex)) {
-    throw new Error('options.useHashIndex value must be of boolean type.');
+  if (!_.isBoolean(options.force)) {
+    throw new Error('options.force value must be of boolean type.');
   }
 
   if (!_.isBoolean(options.log)) {
     throw new Error('options.log value must be of boolean type.');
   }
 
-  if (!_.isBoolean(options.force)) {
-    throw new Error('options.force value must be of boolean type.');
+  if (!_.isNull(options.test) && !_.isRegExp(options.test)) {
+    throw new Error('options.test value must be an instance of RegExp.');
+  }
+
+  if (!_.isBoolean(options.useHashIndex)) {
+    throw new Error('options.useHashIndex value must be of boolean type.');
   }
 
   const log = (...append) => {


### PR DESCRIPTION
I tested and it seems with the latest `webpack-dev-server` version, `output.path` is accessible.

This PR removes the requirement of `devServer.outputPath` for compatibility with Webpack 2.

This is a breaking change so the next version should be `4.0.0`.