### PR TITLE
Add outputPath as plugin option, override conditional checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ export default {
         path: path.join(__dirname, './dist')
     },
     plugins: [
-        new WriteFilePlugin()
+        new WriteFilePlugin(
+            outputPath: path.join(__dirname, './dist')
+        )
     ],
     // ...
 }

--- a/sandbox/webpack.config.js
+++ b/sandbox/webpack.config.js
@@ -5,7 +5,7 @@ var devServer,
 
 webpack = require('webpack');
 path = require('path');
-WriteFileWebpackPlugin = require('./../dist').default;
+WriteFileWebpackPlugin = require('./../dist');
 
 devServer = {
     outputPath: path.join(__dirname, './dist'),
@@ -36,7 +36,8 @@ module.exports = {
     },
     plugins: [
         new WriteFileWebpackPlugin({
-            test: /foo/
+            test: /foo/,
+            outputPath: devServer.outputPath,
         })
     ]
 };

--- a/src/index.js
+++ b/src/index.js
@@ -93,8 +93,8 @@ export default (userOptions: UserOptionsType = {}): Object => {
         return false;
       }
 
-      if (_.has(compiler, 'options.output.path') && compiler.options.output.path !== '/') {
-        outputPath = compiler.options.output.path;
+      if (options.outputPath) {
+        outputPath = options.outputPath;
       }
 
       if (!outputPath) {


### PR DESCRIPTION
This plugin seems to be a little broken?

This PR lets the sandbox work with `webpack@1.14.0` + `webpack-dev-server@1.16.2`.

I don't think this PR should necessarily be merged as it changes the API but I'm just highlighting the problem and a potential solution.

**Additional Details**

**In webpack 1.x**
I couldn't get the sandbox to work with `webpack@1.14.0` + `webpack-dev-server@1.16.2` due to it throwing:
```
output.path is not. Define output.path.
```

**In webpack 2.x**
I couldn't get the sandbox to work with `webpack@2.3.1` + `webpack-dev-server@2.4.2` due to it throwing:

```
Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
...
```

There's clearly been a API change in webpack 2.x since the beta 😄 .
