### PR TITLE
Fix `Data must be a string or a buffer`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -131,7 +131,7 @@ export default (userOptions: UserOptionsType = {}): Object => {
         }
 
         const assetSize = asset.size();
-        const assetSource = asset.source().toString();
+        const assetSource = Array.isArray(asset.source()) ? asset.source().join("\n") : asset.source();
 
         if (options.useHashIndex) {
           const assetSourceHash = createHash('sha256').update(assetSource).digest('hex');

--- a/src/index.js
+++ b/src/index.js
@@ -98,7 +98,7 @@ export default (userOptions: UserOptionsType = {}): Object => {
       }
 
       if (!outputPath) {
-        throw new Error('output.path is not. Define output.path.');
+        throw new Error('output.path is not defined. Define output.path.');
       }
 
       log('outputPath is "' + chalk.cyan(outputPath) + '".');
@@ -131,7 +131,7 @@ export default (userOptions: UserOptionsType = {}): Object => {
         }
 
         const assetSize = asset.size();
-        const assetSource = asset.source();
+        const assetSource = asset.source().toString();
 
         if (options.useHashIndex) {
           const assetSourceHash = createHash('sha256').update(assetSource).digest('hex');


### PR DESCRIPTION
I've had some weird cases where `write-file-webpack-plugin` will cause a `TypeError: Data must be a string or a buffer` error because `asset.source()` returns an array - this PR fixes that by joining the array by new lines.