### PR TITLE
Support webpack 4 and plugin maintenance / dev fixes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,13 @@
 {
+  "presets": [
+    ["env", {
+      "targets": {
+        "node": 4
+      }
+    }]
+  ],
   "plugins": [
     "add-module-exports",
-    "transform-es2015-modules-commonjs",
-    "transform-flow-strip-types",
-    "transform-es2015-parameters",
-    "transform-es2015-spread"
+    "transform-flow-strip-types"
   ]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 node_js:
-  - 7
+  - 8
   - 6
-  - 5
 scripts:
   - npm run test
   - npm run lint

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "BSD-3-Clause",
   "version": "4.2.0",
   "description": "Forces webpack-dev-server to write bundle files to the file system.",
-  "main": "./dist/index.js",
+  "main": "./dist/WriteFileWebpackPlugin.js",
   "author": {
     "name": "Gajus Kuizinas",
     "email": "gk@anuary.com",
@@ -21,7 +21,7 @@
     "file"
   ],
   "engines": {
-    "node": ">=5"
+    "node": ">=4"
   },
   "scripts": {
     "lint": "eslint ./src",
@@ -31,26 +31,24 @@
     "precommit": "npm run lint && npm run test"
   },
   "devDependencies": {
-    "babel-cli": "^6.18.0",
+    "babel-cli": "^6.26.0",
     "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.18.0",
-    "babel-plugin-transform-es2015-parameters": "^6.18.0",
-    "babel-plugin-transform-es2015-spread": "^6.8.0",
-    "babel-plugin-transform-flow-strip-types": "^6.18.0",
+    "babel-plugin-transform-flow-strip-types": "^6.22.0",
+    "babel-preset-env": "^1.6.1",
     "del": "^3.0.0",
-    "eslint": "^3.9.1",
-    "eslint-config-canonical": "^4.0.0",
-    "husky": "^0.11.9",
+    "eslint": "^4.19.1",
+    "eslint-config-canonical": "^9.3.2",
+    "husky": "^0.14.3",
     "webpack": "^4.6.0",
     "webpack-cli": "^2.0.14",
     "webpack-dev-server": "^3.1.3"
   },
   "dependencies": {
-    "chalk": "^1.1.1",
-    "debug": "^2.6.8",
-    "filesize": "^3.2.1",
-    "lodash": "^4.5.1",
+    "chalk": "^2.4.0",
+    "debug": "^3.1.0",
+    "filesize": "^3.6.1",
+    "lodash": "^4.17.5",
     "mkdirp": "^0.5.1",
-    "moment": "^2.19.3"
+    "moment": "^2.22.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,11 +37,13 @@
     "babel-plugin-transform-es2015-parameters": "^6.18.0",
     "babel-plugin-transform-es2015-spread": "^6.8.0",
     "babel-plugin-transform-flow-strip-types": "^6.18.0",
+    "del": "^3.0.0",
     "eslint": "^3.9.1",
     "eslint-config-canonical": "^4.0.0",
     "husky": "^0.11.9",
-    "webpack": "^2.1.0-beta.4",
-    "webpack-dev-server": "^2.0.0-beta"
+    "webpack": "^4.6.0",
+    "webpack-cli": "^2.0.14",
+    "webpack-dev-server": "^3.1.3"
   },
   "dependencies": {
     "chalk": "^1.1.1",

--- a/sandbox/webpack.config.js
+++ b/sandbox/webpack.config.js
@@ -1,28 +1,27 @@
-var devServer,
-    webpack,
-    path,
-    WriteFileWebpackPlugin;
+'use strict';
 
-webpack = require('webpack');
-path = require('path');
-WriteFileWebpackPlugin = require('./../dist').default;
+const path = require('path');
+const WriteFileWebpackPlugin = require('./../dist');
+const del = require('del');
 
-devServer = {
-    outputPath: path.join(__dirname, './dist'),
+const outputPath = path.join(__dirname, './dist');
+const publicPath = '/static/';
+const devServer = {
     contentBase: path.resolve(__dirname, './src'),
-    colors: true,
     quiet: false,
     noInfo: false,
-    publicPath: '/static/',
+    publicPath,
     historyApiFallback: true,
     host: '127.0.0.1',
     port: 8000,
     hot: false
 };
 
+del.sync(path.join(outputPath, '**/*'));
+
 module.exports = {
+    mode: 'development',
     devtool: 'source-map',
-    debug: false,
     devServer: devServer,
     context: path.resolve(__dirname, './src'),
     entry: {
@@ -30,9 +29,9 @@ module.exports = {
         bar: './app'
     },
     output: {
-        path: devServer.outputPath,
+        path: outputPath,
         filename: '[name].js',
-        publicPath: devServer.publicPath
+        publicPath
     },
     plugins: [
         new WriteFileWebpackPlugin({

--- a/sandbox/webpack.config.js
+++ b/sandbox/webpack.config.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const WriteFileWebpackPlugin = require('./../dist');
+const WriteFileWebpackPlugin = require('./../dist/WriteFileWebpackPlugin.js');
 const del = require('del');
 
 const outputPath = path.join(__dirname, './dist');

--- a/src/WriteFileWebpackPlugin.js
+++ b/src/WriteFileWebpackPlugin.js
@@ -108,7 +108,7 @@ export default function WriteFileWebpackPlugin (userOptions: UserOptionsType = {
       return setupStatus;
     };
 
-    compiler.plugin('done', (stats) => {
+    const handleDone = (stats) => {
       if (!setup()) {
         return;
       }
@@ -155,7 +155,22 @@ export default function WriteFileWebpackPlugin (userOptions: UserOptionsType = {
           log(chalk.bold.bgRed('Exception:'), chalk.bold.red(error.message));
         }
       });
-    });
+    };
+
+    /**
+     * webpack 4+ comes with a new plugin system.
+     *
+     * Check for hooks in-order to support old plugin system
+     */
+    if (compiler.hooks) {
+      compiler.hooks.done.tap('write-file-webpack-plugin', (stats) => {
+        handleDone(stats);
+      });
+    } else {
+      compiler.plugin('done', (stats) => {
+        handleDone(stats);
+      });
+    }
   };
 
   return {

--- a/src/WriteFileWebpackPlugin.js
+++ b/src/WriteFileWebpackPlugin.js
@@ -1,7 +1,5 @@
 import fs from 'fs';
-import {
-    createHash
-} from 'crypto';
+import {createHash} from 'crypto';
 import path from 'path';
 import _ from 'lodash';
 import mkdirp from 'mkdirp';
@@ -36,7 +34,7 @@ type UserOptionsType = {
   force: ?boolean
 };
 
-export default (userOptions: UserOptionsType = {}): Object => {
+export default function WriteFileWebpackPlugin (userOptions: UserOptionsType = {}): Object {
   const options = _.assign({}, {
     exitOnErrors: true,
     force: false,
@@ -46,23 +44,23 @@ export default (userOptions: UserOptionsType = {}): Object => {
   }, userOptions);
 
   if (!_.isBoolean(options.exitOnErrors)) {
-    throw new Error('options.exitOnErrors value must be of boolean type.');
+    throw new TypeError('options.exitOnErrors value must be of boolean type.');
   }
 
   if (!_.isBoolean(options.force)) {
-    throw new Error('options.force value must be of boolean type.');
+    throw new TypeError('options.force value must be of boolean type.');
   }
 
   if (!_.isBoolean(options.log)) {
-    throw new Error('options.log value must be of boolean type.');
+    throw new TypeError('options.log value must be of boolean type.');
   }
 
   if (!_.isNull(options.test) && !_.isRegExp(options.test)) {
-    throw new Error('options.test value must be an instance of RegExp.');
+    throw new TypeError('options.test value must be an instance of RegExp.');
   }
 
   if (!_.isBoolean(options.useHashIndex)) {
-    throw new Error('options.useHashIndex value must be of boolean type.');
+    throw new TypeError('options.useHashIndex value must be of boolean type.');
   }
 
   const log = (...append) => {
@@ -78,9 +76,9 @@ export default (userOptions: UserOptionsType = {}): Object => {
   log('options', options);
 
   const apply = (compiler) => {
-    let outputPath,
-      setupDone,
-      setupStatus;
+    let outputPath;
+    let setupDone;
+    let setupStatus;
 
     const setup = (): boolean => {
       if (setupDone) {
@@ -152,9 +150,9 @@ export default (userOptions: UserOptionsType = {}): Object => {
         try {
           fs.writeFileSync(relativeOutputPath.split('?')[0], assetSource);
           log(targetDefinition, chalk.green('[written]'), chalk.magenta('(' + filesize(assetSize) + ')'));
-        } catch (exp) {
+        } catch (error) {
           log(targetDefinition, chalk.bold.red('[is not written]'), chalk.magenta('(' + filesize(assetSize) + ')'));
-          log(chalk.bold.bgRed('Exception:'), chalk.bold.red(exp.message));
+          log(chalk.bold.bgRed('Exception:'), chalk.bold.red(error.message));
         }
       });
     });
@@ -163,4 +161,4 @@ export default (userOptions: UserOptionsType = {}): Object => {
   return {
     apply
   };
-};
+}


### PR DESCRIPTION
This PR:

* Adds support for Webpack 4, while preserving support for the old plugin system.
* Moves over to the recommended``babel-preset-env`` and requires node 4+ (might want to require node 6 lts+ as node 4 is no longer support starting the end of this month).
* Upgrades packages to latest versions and fixes all lint issues.
* Fixes sandbox (was not previously working) and upgrades sandbox config to be compatible with Webpack 4.

I verified Webpack 3 still works as expected.

Closes #50, #32, #52.

I know it isn't normal to have one PR with so many changes, but I was running into several things that was stopping development. For instance, there was a bug with Eslint v3 that was causing a lint error saying ``type UserOptionsType = {`` was not defined. Also, the ``sandbox`` config did not work at all.

If you want this PR split out into separate ones, or want something changed or removed, let me know.