### PR TITLE
Use relativeOutputPath instead of assetPath for hash index map

### DIFF
--- a/src/WriteFileWebpackPlugin.js
+++ b/src/WriteFileWebpackPlugin.js
@@ -149,13 +149,13 @@ export default function WriteFileWebpackPlugin (userOptions: UserOptionsType = {
         if (options.useHashIndex) {
           const assetSourceHash = createHash('sha256').update(assetSource).digest('hex');
 
-          if (assetSourceHashIndex[assetPath] && assetSourceHashIndex[assetPath] === assetSourceHash) {
+          if (assetSourceHashIndex[relativeOutputPath] && assetSourceHashIndex[relativeOutputPath] === assetSourceHash) {
             log(targetDefinition, chalk.yellow('[skipped; matched hash index]'));
 
             return;
           }
 
-          assetSourceHashIndex[assetPath] = assetSourceHash;
+          assetSourceHashIndex[relativeOutputPath] = assetSourceHash;
         }
 
         mkdirp.sync(path.dirname(relativeOutputPath));


### PR DESCRIPTION
In multi compiler mode, there may be two assets with same `assetPath`. 

eg.
``` js
module.exports = [
  {
    context: path.resolve('distA'),
    entry: {
      app: path.resolve('src', 'index.js')
    },
    /* ... */
  },
  {
    context: path.resolve('distB'),
    entry: {
      app: path.resolve('src', 'index.js')
    },
    /* ... */
  }
]
```

Both of the entries have assetPath `app.js`, but they certainly should not use the same hash index.