### PR TITLE
Bump version to 4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "write-file-webpack-plugin",
   "license": "BSD-3-Clause",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Forces webpack-dev-server to write bundle files to the file system.",
   "main": "./dist/WriteFileWebpackPlugin.js",
   "author": {


### PR DESCRIPTION
Add support for Webpack 4, function as a `test` config parameter, and other updates since last release.