### PR TITLE
fix: fix recompilation issue when error occur

### DIFF
--- a/src/WriteFileWebpackPlugin.js
+++ b/src/WriteFileWebpackPlugin.js
@@ -119,7 +119,7 @@ export default function WriteFileWebpackPlugin (userOptions: UserOptionsType = {
 
       if (options.exitOnErrors && compilation.errors.length) {
         // eslint-disable-next-line promise/prefer-await-to-callbacks
-        callback(compilation.errors);
+        callback();
 
         return;
       }


### PR DESCRIPTION
Do not calls callback with error to prevent recompilation from stopping when error occur.
Reason: 
By design, after-emit will stops recompilation if a plugin calls callback with error.
https://github.com/webpack/webpack/issues/4326
fix
#63 