### PR TITLE
feat: Replace output files atomically (new option: atomicReplace).

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ npm install write-file-webpack-plugin --save-dev
 ```js
 /**
  * @typedef {Object} options
+ * @property {boolean} atomicReplace Atomically replace files content (i.e., to prevent programs like test watchers from seeing partial files) (default: true).
  * @property {boolean} exitOnErrors Stop writing files on webpack errors (default: true).
  * @property {boolean} force Forces the execution of the plugin regardless of being using `webpack-dev-server` or not (default: false).
  * @property {boolean} log Logs names of the files that are being written (or skipped because they have not changed) (default: true).

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "filesize": "^3.6.1",
     "lodash": "^4.17.5",
     "mkdirp": "^0.5.1",
-    "moment": "^2.22.1"
+    "moment": "^2.22.1",
+    "write-file-atomic": "^2.3.0"
   }
 }


### PR DESCRIPTION
This is useful if the written files are watched by an external program
like test watchers (i.e., karma). Without an atomic replace, these
programs may process an incomplete file. This usually results in syntax
errors being reported.

This commit introduces an atomic replacement strategy whereby the new
version of a file is written to a temporary file. When the file is
completely written, the temporary file is renamed to the output file
name, replacing the contents atomically. This strategy can be disabled
via the atomicReplace boolean option.