### PR TITLE
Replacing moment with time-stamp

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "filesize": "^3.6.1",
     "lodash": "^4.17.5",
     "mkdirp": "^0.5.1",
-    "moment": "^2.22.1",
+    "time-stamp": "^2.1.0",
     "write-file-atomic": "^2.3.0"
   }
 }

--- a/src/WriteFileWebpackPlugin.js
+++ b/src/WriteFileWebpackPlugin.js
@@ -4,7 +4,7 @@ import path from 'path';
 import _ from 'lodash';
 import mkdirp from 'mkdirp';
 import chalk from 'chalk';
-import moment from 'moment';
+import timestamp from 'time-stamp';
 import filesize from 'filesize';
 import createDebug from 'debug';
 import {sync as writeFileAtomicSync} from 'write-file-atomic';
@@ -78,7 +78,7 @@ export default function WriteFileWebpackPlugin (userOptions: UserOptionsType = {
       return;
     }
 
-    debug(chalk.dim('[' + moment().format('HH:mm:ss') + '] [write-file-webpack-plugin]'), ...append);
+    debug(chalk.dim('[' + timestamp('HH:mm:ss') + '] [write-file-webpack-plugin]'), ...append);
   };
 
   const assetSourceHashIndex = {};


### PR DESCRIPTION
There is no need for all the capabilities in moment for one debug log
line. And the bundle size gets a lot smaller.

The current minified size is **339.9 kB** with Moment taking up 62.6% of the size.
https://bundlephobia.com/result?p=write-file-webpack-plugin@4.4.0

After this change the minified size becomes **111.4 kB**