### PR TITLE
fix: Prevent the plugin from crashing if asset size is undefined

### DIFF
--- a/src/WriteFileWebpackPlugin.js
+++ b/src/WriteFileWebpackPlugin.js
@@ -165,7 +165,7 @@ export default function WriteFileWebpackPlugin (userOptions: UserOptionsType = {
           }
         }
 
-        const assetSize = asset.size();
+        const assetSize = asset.size() || 0;
         const assetSource = getAssetSource(asset);
 
         if (options.useHashIndex) {

--- a/src/WriteFileWebpackPlugin.js
+++ b/src/WriteFileWebpackPlugin.js
@@ -165,6 +165,7 @@ export default function WriteFileWebpackPlugin (userOptions: UserOptionsType = {
           }
         }
 
+        // asset.size method returns `undefined` for binary files (e.g. WASM). This is a temporarily workaround.
         const assetSize = asset.size() || 0;
         const assetSource = getAssetSource(asset);
 


### PR DESCRIPTION
For some reason, with binary files (e.g. WASM files), the `asset.size` method will return undefined. This causes an error when passing undefined into the `filesize` package, since it expects a number. This defaults it to 0.