### PR TITLE
chore: upgrade lodash due to CVE-2019-10744

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "chalk": "^2.4.0",
     "debug": "^3.1.0",
     "filesize": "^3.6.1",
-    "lodash": "^4.17.5",
+    "lodash": "^4.17.13",
     "mkdirp": "^0.5.1",
     "moment": "^2.22.1",
     "write-file-atomic": "^2.3.0"


### PR DESCRIPTION
https://github.com/lodash/lodash/pull/4336